### PR TITLE
Proper fix for titleLabel autolayout width in StoriesTableViewCell

### DIFF
--- a/DesignerNewsApp/StoriesTableViewCell.swift
+++ b/DesignerNewsApp/StoriesTableViewCell.swift
@@ -51,4 +51,12 @@ class StoriesTableViewCell: UITableViewCell {
         layer.force = 3
         layer.animate()
     }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        if let titleLabel = self.titleLabel {
+            titleLabel.preferredMaxLayoutWidth = titleLabel.frame.size.width ?? 0
+        }
+    }
 }

--- a/DesignerNewsApp/StoriesTableViewController.swift
+++ b/DesignerNewsApp/StoriesTableViewController.swift
@@ -187,7 +187,6 @@ class StoriesTableViewController: UITableViewController, StoriesTableViewCellDel
     
     func configureCell(cell: StoriesTableViewCell, story: JSON) {
 
-        cell.titleLabel.layoutSubviews()
         cell.titleLabel.text = story["title"].string
         
         if let name = story["user_display_name"].string? {


### PR DESCRIPTION
- I would also suggest considering using optionals for the IBOutlets if you decided to reuse the same cell class for both Stories and Comments, this reflects the reality of the prototype cell. Holding on right now until the decision of single or difference cell classes has been made.
