### PR TITLE
Use AsyncImageView instead of ImageLoader 

### DIFF
--- a/DesignerNewsApp.xcodeproj/project.pbxproj
+++ b/DesignerNewsApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		1A908E471A74A44600F30022 /* Commentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A908E461A74A44600F30022 /* Commentable.swift */; };
 		1A908E671A753B6C00F30022 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A908E661A753B6C00F30022 /* libxml2.dylib */; };
 		1A9183091A75EE1900606F35 /* CoreTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9183081A75EE1900606F35 /* CoreTextView.swift */; };
+		1AAA95C21A79144000D5E8C8 /* AsyncImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAA95C11A79144000D5E8C8 /* AsyncImageView.swift */; };
 		1AB33B591A7660E800E3AB55 /* libDTCoreText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AB33B501A7660B300E3AB55 /* libDTCoreText.a */; };
 		961889B21A67F15900295A64 /* TPKeyboardAvoidingCollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 961889AB1A67F15900295A64 /* TPKeyboardAvoidingCollectionView.m */; };
 		961889B31A67F15900295A64 /* TPKeyboardAvoidingScrollView.m in Sources */ = {isa = PBXBuildFile; fileRef = 961889AD1A67F15900295A64 /* TPKeyboardAvoidingScrollView.m */; };
@@ -187,6 +188,7 @@
 		1A908E611A75382200F30022 /* DesignerNewsApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DesignerNewsApp-Bridging-Header.h"; sourceTree = "<group>"; };
 		1A908E661A753B6C00F30022 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
 		1A9183081A75EE1900606F35 /* CoreTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreTextView.swift; sourceTree = "<group>"; };
+		1AAA95C11A79144000D5E8C8 /* AsyncImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncImageView.swift; sourceTree = "<group>"; };
 		1AB33B3F1A7660B300E3AB55 /* DTCoreText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DTCoreText.xcodeproj; path = DTCoreText/DTCoreText.xcodeproj; sourceTree = "<group>"; };
 		961889AA1A67F15900295A64 /* TPKeyboardAvoidingCollectionView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPKeyboardAvoidingCollectionView.h; sourceTree = "<group>"; };
 		961889AB1A67F15900295A64 /* TPKeyboardAvoidingCollectionView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPKeyboardAvoidingCollectionView.m; sourceTree = "<group>"; };
@@ -430,6 +432,7 @@
 			isa = PBXGroup;
 			children = (
 				1A9183081A75EE1900606F35 /* CoreTextView.swift */,
+				1AAA95C11A79144000D5E8C8 /* AsyncImageView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -691,6 +694,7 @@
 				9694F20B1A6123D000A6376A /* WebViewController.swift in Sources */,
 				B78F90411A6EFBAF00883A5B /* Story.swift in Sources */,
 				96AF96171A5EABC9003926E2 /* StoryTableViewCell.swift in Sources */,
+				1AAA95C21A79144000D5E8C8 /* AsyncImageView.swift in Sources */,
 				1A9183091A75EE1900606F35 /* CoreTextView.swift in Sources */,
 				B7E4D3371A719855001DC9B6 /* CommentTableViewCell.swift in Sources */,
 				961889B41A67F15900295A64 /* TPKeyboardAvoidingTableView.m in Sources */,

--- a/DesignerNewsApp/AsyncImageView.swift
+++ b/DesignerNewsApp/AsyncImageView.swift
@@ -1,0 +1,36 @@
+//
+//  AsyncImageView.swift
+//  DesignerNewsApp
+//
+//  Created by James Tang on 28/1/15.
+//  Copyright (c) 2015 Meng To. All rights reserved.
+//
+
+import UIKit
+import Spring
+
+public class AsyncImageView: UIImageView {
+
+    var placeholderImage : UIImage?
+
+    var url : NSURL? {
+        didSet {
+            self.image = placeholderImage
+            if let urlString = url?.absoluteString {
+                ImageLoader.sharedLoader.imageForUrl(urlString) { [weak self] image, url in
+                    if let strongSelf = self {
+                        if strongSelf.url?.absoluteString == url {
+                            strongSelf.image = image
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func setURL(url: NSURL?, placeholderImage: UIImage?) {
+        self.placeholderImage = placeholderImage
+        self.url = url
+    }
+
+}

--- a/DesignerNewsApp/Base.lproj/Main.storyboard
+++ b/DesignerNewsApp/Base.lproj/Main.storyboard
@@ -274,7 +274,7 @@
                                                 <constraint firstAttribute="width" constant="20" id="tx9-eL-RCA"/>
                                             </constraints>
                                         </imageView>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6U6-ia-R5S">
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6U6-ia-R5S" customClass="AsyncImageView" customModule="DesignerNewsApp" customModuleProvider="target">
                                             <rect key="frame" x="35" y="40" width="10" height="10"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="10" id="KFq-Ji-gOm"/>
@@ -893,7 +893,7 @@
                                                 <constraint firstAttribute="height" constant="20" id="mzD-lj-z6k"/>
                                             </constraints>
                                         </imageView>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="xC5-N7-dVN">
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="xC5-N7-dVN" customClass="AsyncImageView" customModule="DesignerNewsApp" customModuleProvider="target">
                                             <rect key="frame" x="37" y="41" width="10" height="10"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" priority="999" constant="10" id="Gh1-Kh-T31"/>
@@ -1013,7 +1013,7 @@
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="nG4-aS-hFF" id="mwj-X7-b1i">
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="CkY-NW-Xvu">
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="CkY-NW-Xvu" customClass="AsyncImageView" customModule="DesignerNewsApp" customModuleProvider="target">
                                             <rect key="frame" x="8" y="10" width="20" height="20"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="20" id="VNm-oL-mtT"/>

--- a/DesignerNewsApp/CommentTableViewCell.swift
+++ b/DesignerNewsApp/CommentTableViewCell.swift
@@ -18,7 +18,7 @@ import Spring
 
 class CommentTableViewCell: UITableViewCell, CoreTextViewDelegate {
     @IBOutlet weak var authorLabel: UILabel!
-    @IBOutlet weak var avatarImageView: UIImageView!
+    @IBOutlet weak var avatarImageView: AsyncImageView!
     @IBOutlet weak var replyButton: SpringButton!
     @IBOutlet weak var upvoteButton: SpringButton!
     @IBOutlet weak var timeLabel: UILabel!
@@ -75,14 +75,11 @@ extension CommentTableViewCell {
 
         self.authorLabel.text = comment.userDisplayName + ", " + comment.userJob
         self.upvoteButton.setTitle(toString(comment.voteCount), forState: UIControlState.Normal)
-        self.avatarImageView.image = UIImage(named: "content-avatar-default")
 
         let timeAgo = dateFromString(comment.createdAt, "yyyy-MM-dd'T'HH:mm:ssZ")
         self.timeLabel.text = timeAgoSinceDate(timeAgo, true)
 
-        ImageLoader.sharedLoader.imageForUrl(comment.userPortraitUrl, completionHandler:{ image, _ in
-            self.avatarImageView.image = image
-        })
+        self.avatarImageView.setURL(NSURL(string: comment.userPortraitUrl), placeholderImage: UIImage(named: "content-avatar-default"))
 
         // Make sure the textView are correctly framed before setting attributed string
         self.setNeedsLayout()

--- a/DesignerNewsApp/StoryTableViewCell.swift
+++ b/DesignerNewsApp/StoryTableViewCell.swift
@@ -21,7 +21,7 @@ import Spring
 class StoryTableViewCell: UITableViewCell, CoreTextViewDelegate {
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var authorLabel: UILabel!
-    @IBOutlet weak var avatarImageView: UIImageView!
+    @IBOutlet weak var avatarImageView: AsyncImageView!
     @IBOutlet weak var storyImageView: UIImageView!
     @IBOutlet weak var commentButton: SpringButton?
     @IBOutlet weak var replyButton: SpringButton?
@@ -83,7 +83,6 @@ extension StoryTableViewCell {
         self.authorLabel.text = story.userDisplayName + ", " + story.userJob
         self.upvoteButton.setTitle(toString(story.voteCount), forState: UIControlState.Normal)
         self.storyImageView.image = story.badge.isEmpty ? nil : UIImage(named: "badge-\(story.badge)")
-        self.avatarImageView.image = UIImage(named: "content-avatar-default")
 
         let timeAgo = dateFromString(story.createdAt, "yyyy-MM-dd'T'HH:mm:ssZ")
         self.timeLabel.text = timeAgoSinceDate(timeAgo, true)
@@ -91,9 +90,7 @@ extension StoryTableViewCell {
         let imageName = isUpvoted ? "icon-upvote-active" : "icon-upvote"
         self.upvoteButton.setImage(UIImage(named: imageName), forState: UIControlState.Normal)
 
-        ImageLoader.sharedLoader.imageForUrl(story.userPortraitUrl, completionHandler:{ image, _ in
-            self.avatarImageView.image = image
-        })
+        self.avatarImageView.setURL(NSURL(string: story.userPortraitUrl), placeholderImage: UIImage(named: "content-avatar-default"))
 
         if let commentTextView = self.commentTextView {
 


### PR DESCRIPTION
to make sure small avatars won’t accidentally refresh. Fixes #30 
