### PR TITLE
Fixing text layout after rotation

### DIFF
--- a/DesignerNewsApp/CommentsTableViewController.swift
+++ b/DesignerNewsApp/CommentsTableViewController.swift
@@ -29,7 +29,14 @@ class CommentsTableViewController: UITableViewController, StoryTableViewCellDele
         super.viewDidAppear(animated)
         UIApplication.sharedApplication().setStatusBarHidden(false, withAnimation: UIStatusBarAnimation.Fade)
     }
-    
+
+    override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
+        coordinator.animateAlongsideTransition(nil, completion: { (context) -> Void in
+            self.tableView.reloadData()
+        })
+    }
+
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
         if segue.identifier == "ReplySegue" {
 

--- a/DesignerNewsApp/CoreTextView.swift
+++ b/DesignerNewsApp/CoreTextView.swift
@@ -20,6 +20,12 @@ class CoreTextView: DTAttributedTextContentView, DTAttributedTextContentViewDele
     weak var linkDelegate : CoreTextViewDelegate?
     private var imageViews = [DTLazyImageView]()
 
+    override var bounds : CGRect {
+        didSet {
+            self.relayoutText()
+        }
+    }
+
     required init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         self.delegate = self


### PR DESCRIPTION
![slack_for_ios_upload_1024](https://cloud.githubusercontent.com/assets/852375/6683920/02942b1e-ccc7-11e4-8a53-af2d4b2c41b2.png)

Our problem is that after rotation, text are not utilising the width of the cell. Although we've properly configured our auto layout constraints on that, the problem actually lies in how **DTCoreTextContentView** implemented.

1. My patch makes sure **CoreTextView** always `relayoutText()` if `bounds` has changed
2. The our VC should reload our table view after rotation since cell height is probably changed.

This might not be perfect but definitely more reliable in my testing.