### PR TITLE
Use UIPageViewController to allow swiping between Top/Recent Stories

### DIFF
--- a/DesignerNewsApp.xcodeproj/project.pbxproj
+++ b/DesignerNewsApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1A2331C41A78DFAF002F8D80 /* LoadingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2331C31A78DFAF002F8D80 /* LoadingTableViewCell.swift */; };
 		1A2331D21A78E1AF002F8D80 /* StoriesLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2331D11A78E1AF002F8D80 /* StoriesLoader.swift */; };
+		1A2849971AB9D3F900940CE3 /* LoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2849961AB9D3F900940CE3 /* LoginService.swift */; };
 		1A7D78A01A70F8FE0061D6F6 /* DragDropBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7D789F1A70F8FE0061D6F6 /* DragDropBehavior.swift */; };
 		1A8D9C811A75E3000032DA0F /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A8D9C801A75E3000032DA0F /* ImageIO.framework */; };
 		1A8D9C841A75E30F0032DA0F /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A8D9C831A75E30F0032DA0F /* QuartzCore.framework */; };
@@ -184,6 +185,7 @@
 /* Begin PBXFileReference section */
 		1A2331C31A78DFAF002F8D80 /* LoadingTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingTableViewCell.swift; sourceTree = "<group>"; };
 		1A2331D11A78E1AF002F8D80 /* StoriesLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoriesLoader.swift; sourceTree = "<group>"; };
+		1A2849961AB9D3F900940CE3 /* LoginService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginService.swift; sourceTree = "<group>"; };
 		1A4FDA211A6E43FE0099D309 /* SpringApp.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SpringApp.xcodeproj; path = Spring/SpringApp.xcodeproj; sourceTree = "<group>"; };
 		1A7D789F1A70F8FE0061D6F6 /* DragDropBehavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DragDropBehavior.swift; sourceTree = "<group>"; };
 		1A8D9C801A75E3000032DA0F /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
@@ -427,6 +429,7 @@
 				B78F90371A6EF75800883A5B /* DesignerNewsService.swift */,
 				1A2331D11A78E1AF002F8D80 /* StoriesLoader.swift */,
 				B773D86E1A7BC101008E8A65 /* LocalStore.swift */,
+				1A2849961AB9D3F900940CE3 /* LoginService.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -694,6 +697,7 @@
 			files = (
 				964892671A63F5D900214D53 /* MenuViewController.swift in Sources */,
 				961889B81A680D3800295A64 /* LearnViewController.swift in Sources */,
+				1A2849971AB9D3F900940CE3 /* LoginService.swift in Sources */,
 				1AB6351C1AB6D46900064D14 /* ContainerViewController.swift in Sources */,
 				966128551A4DA63100A54A23 /* AppDelegate.swift in Sources */,
 				B773D86F1A7BC101008E8A65 /* LocalStore.swift in Sources */,

--- a/DesignerNewsApp.xcodeproj/project.pbxproj
+++ b/DesignerNewsApp.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		1A935E3A1A837B980059BCBC /* upvote.wav in Resources */ = {isa = PBXBuildFile; fileRef = 1A935E381A837B980059BCBC /* upvote.wav */; };
 		1A935E3C1A837C640059BCBC /* SoundPlayer+DesignerNewsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A935E3B1A837C640059BCBC /* SoundPlayer+DesignerNewsApp.swift */; };
 		1AB33B591A7660E800E3AB55 /* libDTCoreText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AB33B501A7660B300E3AB55 /* libDTCoreText.a */; };
+		1AB6351C1AB6D46900064D14 /* ContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB6351B1AB6D46900064D14 /* ContainerViewController.swift */; };
 		1AED4A711A7BBCCA004C689E /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AED4A701A7BBCCA004C689E /* Error.swift */; };
 		961889B81A680D3800295A64 /* LearnViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961889B71A680D3800295A64 /* LearnViewController.swift */; };
 		964892151A62A84600214D53 /* ReplyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964892141A62A84600214D53 /* ReplyViewController.swift */; };
@@ -205,6 +206,7 @@
 		1A935E381A837B980059BCBC /* upvote.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = upvote.wav; sourceTree = "<group>"; };
 		1A935E3B1A837C640059BCBC /* SoundPlayer+DesignerNewsApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SoundPlayer+DesignerNewsApp.swift"; sourceTree = "<group>"; };
 		1AB33B3F1A7660B300E3AB55 /* DTCoreText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DTCoreText.xcodeproj; path = DTCoreText/DTCoreText.xcodeproj; sourceTree = "<group>"; };
+		1AB6351B1AB6D46900064D14 /* ContainerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerViewController.swift; sourceTree = "<group>"; };
 		1AED4A701A7BBCCA004C689E /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		961889B71A680D3800295A64 /* LearnViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LearnViewController.swift; sourceTree = "<group>"; };
 		964892141A62A84600214D53 /* ReplyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReplyViewController.swift; sourceTree = "<group>"; };
@@ -413,6 +415,7 @@
 				964892661A63F5D900214D53 /* MenuViewController.swift */,
 				961889B71A680D3800295A64 /* LearnViewController.swift */,
 				966128541A4DA63100A54A23 /* AppDelegate.swift */,
+				1AB6351B1AB6D46900064D14 /* ContainerViewController.swift */,
 			);
 			name = "View Controllers";
 			sourceTree = "<group>";
@@ -691,6 +694,7 @@
 			files = (
 				964892671A63F5D900214D53 /* MenuViewController.swift in Sources */,
 				961889B81A680D3800295A64 /* LearnViewController.swift in Sources */,
+				1AB6351C1AB6D46900064D14 /* ContainerViewController.swift in Sources */,
 				966128551A4DA63100A54A23 /* AppDelegate.swift in Sources */,
 				B773D86F1A7BC101008E8A65 /* LocalStore.swift in Sources */,
 				1A7D78A01A70F8FE0061D6F6 /* DragDropBehavior.swift in Sources */,

--- a/DesignerNewsApp/Base.lproj/Main.storyboard
+++ b/DesignerNewsApp/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14D87h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="tth-uE-yGl">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14D87h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="tth-uE-yGl">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6246"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -39,7 +39,7 @@
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4bh-8f-iPL" customClass="SpringView" customModule="Spring">
                                                     <rect key="frame" x="160" y="160" width="280" height="280"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Log in to" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3iX-v0-KfP">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Log in to" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3iX-v0-KfP">
                                                             <rect key="frame" x="100" y="25" width="80" height="28"/>
                                                             <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="20"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -251,7 +251,26 @@
             <objects>
                 <pageViewController autoresizesArchivedViewToFullSize="NO" automaticallyAdjustsScrollViewInsets="NO" transitionStyle="scroll" navigationOrientation="horizontal" spineLocation="none" id="Hk8-Sl-9f6" customClass="ContainerViewController" customModule="DesignerNewsApp" customModuleProvider="target" sceneMemberID="viewController">
                     <extendedEdge key="edgesForExtendedLayout" bottom="YES"/>
-                    <navigationItem key="navigationItem" id="Ize-65-uX8"/>
+                    <navigationItem key="navigationItem" id="Ize-65-uX8">
+                        <barButtonItem key="leftBarButtonItem" id="ttR-gz-v7X">
+                            <view key="customView" contentMode="scaleToFill" id="OcC-gl-EFu" customClass="MenuControl" customModule="DesignerNewsApp" customModuleProvider="target">
+                                <rect key="frame" x="16" y="5" width="26" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="color">
+                                        <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="menuButtonTouched:" destination="Hk8-Sl-9f6" eventType="touchUpInside" id="kGf-XR-OOr"/>
+                                </connections>
+                            </view>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <segue destination="G2J-Ma-fKq" kind="presentation" identifier="MenuSegue" modalPresentationStyle="overCurrentContext" animates="NO" id="cCn-3h-med"/>
+                    </connections>
                 </pageViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bMl-vV-eSF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -399,8 +418,8 @@
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="vq3-1F-uVG" id="6te-PW-AQw">
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <activityIndicatorView opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="Of0-IL-gkm">
-                                            <rect key="frame" x="290" y="20" width="20" height="20.5"/>
+                                        <activityIndicatorView opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" animating="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="Of0-IL-gkm">
+                                            <rect key="frame" x="290" y="20" width="20" height="21"/>
                                         </activityIndicatorView>
                                     </subviews>
                                     <constraints>
@@ -421,21 +440,6 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="Top Stories" id="JGT-YY-uoi">
-                        <barButtonItem key="leftBarButtonItem" id="ttR-gz-v7X">
-                            <view key="customView" contentMode="scaleToFill" id="OcC-gl-EFu" customClass="MenuControl" customModule="DesignerNewsApp" customModuleProvider="target">
-                                <rect key="frame" x="16" y="5" width="26" height="18"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="color">
-                                        <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <action selector="menuButtonTouched:" destination="VA5-Ik-jqO" eventType="touchUpInside" id="1PT-Bh-H4r"/>
-                                </connections>
-                            </view>
-                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="Login" id="uej-tB-xeq">
                             <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                             <connections>
@@ -960,7 +964,7 @@
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="4h" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Uc-qd-Y6d">
-                                            <rect key="frame" x="560" y="11" width="32" height="20.5"/>
+                                            <rect key="frame" x="560" y="11" width="32" height="21"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" priority="999" constant="32" id="y48-wy-Hvh"/>
                                             </constraints>
@@ -1081,7 +1085,7 @@
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mLN-xj-Mqg">
-                                            <rect key="frame" x="35" y="10" width="520" height="19.5"/>
+                                            <rect key="frame" x="35" y="10" width="520" height="20"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="19.5" id="2Cr-Rc-eqV"/>
                                             </constraints>
@@ -1089,7 +1093,7 @@
                                             <color key="textColor" red="0.58823529411764708" green="0.65098039215686276" blue="0.70980392156862748" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="247" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JGm-ww-iWK" customClass="SpringButton" customModule="Spring">
+                                        <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="247" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JGm-ww-iWK" customClass="SpringButton" customModule="Spring">
                                             <rect key="frame" x="25" y="28" width="60" height="33"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="60" id="Z9x-Kz-88e"/>
@@ -1107,7 +1111,7 @@
                                                 <action selector="upvoteButtonPressed:" destination="nG4-aS-hFF" eventType="touchUpInside" id="MfG-6l-wFb"/>
                                             </connections>
                                         </button>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rGU-1m-Bb5" customClass="SpringButton" customModule="Spring">
+                                        <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rGU-1m-Bb5" customClass="SpringButton" customModule="Spring">
                                             <rect key="frame" x="85" y="28" width="80" height="33"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="80" id="0ZW-iM-6PG"/>
@@ -1125,7 +1129,7 @@
                                             </connections>
                                         </button>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4h" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8nu-Cg-qpV">
-                                            <rect key="frame" x="574" y="10" width="17.5" height="20.5"/>
+                                            <rect key="frame" x="574" y="10" width="18" height="21"/>
                                             <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="15"/>
                                             <color key="textColor" red="0.58823529411764708" green="0.65098039215686276" blue="0.70980392156862748" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
@@ -1143,8 +1147,8 @@
                                                 </mask>
                                             </variation>
                                         </view>
-                                        <view contentMode="scaleToFill" horizontalHuggingPriority="249" verticalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="zRo-Ar-eV4" customClass="CoreTextView" customModule="DesignerNewsApp" customModuleProvider="target">
-                                            <rect key="frame" x="35" y="64" width="550" height="35.5"/>
+                                        <view contentMode="scaleToFill" horizontalHuggingPriority="249" verticalCompressionResistancePriority="749" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zRo-Ar-eV4" customClass="CoreTextView" customModule="DesignerNewsApp" customModuleProvider="target">
+                                            <rect key="frame" x="35" y="64" width="550" height="36"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         </view>
                                     </subviews>
@@ -1340,5 +1344,6 @@
     <inferredMetricsTieBreakers>
         <segue reference="Jya-5Y-T44"/>
         <segue reference="4dT-jd-Noy"/>
+        <segue reference="cCn-3h-med"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/DesignerNewsApp/Base.lproj/Main.storyboard
+++ b/DesignerNewsApp/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14D72i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="tth-uE-yGl">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14D87h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="tth-uE-yGl">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -246,10 +246,21 @@
             </objects>
             <point key="canvasLocation" x="-445" y="2499"/>
         </scene>
+        <!--Container View Controller-->
+        <scene sceneID="jFr-pz-fev">
+            <objects>
+                <pageViewController autoresizesArchivedViewToFullSize="NO" automaticallyAdjustsScrollViewInsets="NO" transitionStyle="scroll" navigationOrientation="horizontal" spineLocation="none" id="Hk8-Sl-9f6" customClass="ContainerViewController" customModule="DesignerNewsApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <extendedEdge key="edgesForExtendedLayout" bottom="YES"/>
+                    <navigationItem key="navigationItem" id="Ize-65-uX8"/>
+                </pageViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="bMl-vV-eSF" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="246" y="1714"/>
+        </scene>
         <!--Top Stories-->
         <scene sceneID="Q2e-Ny-1C0">
             <objects>
-                <tableViewController id="VA5-Ik-jqO" customClass="StoriesTableViewController" customModule="DesignerNewsApp" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController storyboardIdentifier="StoriesTableViewController" id="VA5-Ik-jqO" customClass="StoriesTableViewController" customModule="DesignerNewsApp" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="100" sectionHeaderHeight="22" sectionFooterHeight="22" id="0v6-GZ-Lmr">
                         <rect key="frame" x="0.0" y="64" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1062,7 +1073,7 @@
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="nG4-aS-hFF" id="mwj-X7-b1i">
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                      <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="CkY-NW-Xvu" customClass="AsyncImageView" customModule="Spring">
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="CkY-NW-Xvu" customClass="AsyncImageView" customModule="Spring">
                                             <rect key="frame" x="8" y="10" width="20" height="20"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="20" id="VNm-oL-mtT"/>
@@ -1297,12 +1308,12 @@
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
-                        <segue destination="VA5-Ik-jqO" kind="relationship" relationship="rootViewController" id="XPw-9U-khN"/>
+                        <segue destination="Hk8-Sl-9f6" kind="relationship" relationship="rootViewController" id="ulD-Mj-Auz"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0C4-1R-y3z" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="246" y="1714"/>
+            <point key="canvasLocation" x="-445" y="1713"/>
         </scene>
     </scenes>
     <resources>

--- a/DesignerNewsApp/Base.lproj/Main.storyboard
+++ b/DesignerNewsApp/Base.lproj/Main.storyboard
@@ -8,7 +8,7 @@
         <!--Login View Controller-->
         <scene sceneID="Gna-wh-cmr">
             <objects>
-                <viewController id="maI-eQ-OKD" customClass="LoginViewController" customModule="DesignerNewsApp" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginViewController" id="maI-eQ-OKD" customClass="LoginViewController" customModule="DesignerNewsApp" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="FLK-WL-idC"/>
                         <viewControllerLayoutGuide type="bottom" id="kND-C6-oR4"/>
@@ -277,7 +277,6 @@
                     <connections>
                         <outlet property="loginButton" destination="uej-tB-xeq" id="60g-I8-Sk7"/>
                         <segue destination="G2J-Ma-fKq" kind="presentation" identifier="MenuSegue" modalPresentationStyle="overCurrentContext" animates="NO" id="cCn-3h-med"/>
-                        <segue destination="maI-eQ-OKD" kind="presentation" identifier="LoginSegue" modalPresentationStyle="overCurrentContext" modalTransitionStyle="crossDissolve" animates="NO" id="gYg-Tj-m7u"/>
                     </connections>
                 </pageViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bMl-vV-eSF" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -459,7 +458,6 @@
                         <segue destination="HBs-bl-KVv" kind="show" identifier="CommentsSegue" id="3HB-vO-v5a"/>
                         <segue destination="d4v-hq-Ei2" kind="presentation" identifier="WebSegue" id="Jya-5Y-T44"/>
                         <segue destination="G2J-Ma-fKq" kind="presentation" identifier="MenuSegue" modalPresentationStyle="overCurrentContext" animates="NO" id="hNl-2w-BvP"/>
-                        <segue destination="maI-eQ-OKD" kind="presentation" identifier="LoginSegue" modalPresentationStyle="overCurrentContext" modalTransitionStyle="crossDissolve" animates="NO" id="VhH-Aa-bkq"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="py4-Yi-ebA" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -745,7 +743,6 @@
                         <outlet property="loginLabel" destination="9fv-eC-1JO" id="0hL-qt-uhk"/>
                         <outlet property="recentLabel" destination="8hj-pg-WtG" id="gIc-VZ-Ln5"/>
                         <outlet property="topLabel" destination="JaA-rV-WKv" id="k8O-NT-LDT"/>
-                        <segue destination="maI-eQ-OKD" kind="presentation" identifier="LoginSegue" modalTransitionStyle="crossDissolve" animates="NO" id="k70-GR-7l8"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ght-xt-R2Z" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1207,7 +1204,6 @@
                     <connections>
                         <segue destination="Ud9-EQ-k4v" kind="presentation" identifier="ReplySegue" id="AAA-ja-nOX"/>
                         <segue destination="d4v-hq-Ei2" kind="presentation" identifier="WebSegue" id="WYa-K1-lob"/>
-                        <segue destination="maI-eQ-OKD" kind="presentation" identifier="LoginSegue" modalPresentationStyle="overCurrentContext" modalTransitionStyle="crossDissolve" animates="NO" id="Sm2-a6-0WS"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Pxf-D7-GjD" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1343,7 +1339,6 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="Jya-5Y-T44"/>
-        <segue reference="gYg-Tj-m7u"/>
         <segue reference="cCn-3h-med"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/DesignerNewsApp/Base.lproj/Main.storyboard
+++ b/DesignerNewsApp/Base.lproj/Main.storyboard
@@ -267,9 +267,17 @@
                                 </connections>
                             </view>
                         </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="Login" id="uej-tB-xeq">
+                            <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                            <connections>
+                                <action selector="loginButtonPressed:" destination="Hk8-Sl-9f6" id="B6A-HX-sJd"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="loginButton" destination="uej-tB-xeq" id="60g-I8-Sk7"/>
                         <segue destination="G2J-Ma-fKq" kind="presentation" identifier="MenuSegue" modalPresentationStyle="overCurrentContext" animates="NO" id="cCn-3h-med"/>
+                        <segue destination="maI-eQ-OKD" kind="presentation" identifier="LoginSegue" modalPresentationStyle="overCurrentContext" modalTransitionStyle="crossDissolve" animates="NO" id="gYg-Tj-m7u"/>
                     </connections>
                 </pageViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bMl-vV-eSF" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -439,14 +447,7 @@
                             <outlet property="delegate" destination="VA5-Ik-jqO" id="n0W-Q9-DHi"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Top Stories" id="JGT-YY-uoi">
-                        <barButtonItem key="rightBarButtonItem" title="Login" id="uej-tB-xeq">
-                            <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                            <connections>
-                                <action selector="loginButtonPressed:" destination="VA5-Ik-jqO" id="3H0-DK-seP"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="Top Stories" id="JGT-YY-uoi"/>
                     <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="jrj-W6-HAL">
                         <autoresizingMask key="autoresizingMask"/>
                         <connections>
@@ -455,11 +456,10 @@
                         </connections>
                     </refreshControl>
                     <connections>
-                        <outlet property="loginButton" destination="uej-tB-xeq" id="f8E-KV-P3z"/>
                         <segue destination="HBs-bl-KVv" kind="show" identifier="CommentsSegue" id="3HB-vO-v5a"/>
                         <segue destination="d4v-hq-Ei2" kind="presentation" identifier="WebSegue" id="Jya-5Y-T44"/>
-                        <segue destination="maI-eQ-OKD" kind="presentation" identifier="LoginSegue" modalPresentationStyle="overCurrentContext" modalTransitionStyle="crossDissolve" animates="NO" id="4dT-jd-Noy"/>
                         <segue destination="G2J-Ma-fKq" kind="presentation" identifier="MenuSegue" modalPresentationStyle="overCurrentContext" animates="NO" id="hNl-2w-BvP"/>
+                        <segue destination="maI-eQ-OKD" kind="presentation" identifier="LoginSegue" modalPresentationStyle="overCurrentContext" modalTransitionStyle="crossDissolve" animates="NO" id="VhH-Aa-bkq"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="py4-Yi-ebA" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1343,7 +1343,7 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="Jya-5Y-T44"/>
-        <segue reference="4dT-jd-Noy"/>
+        <segue reference="gYg-Tj-m7u"/>
         <segue reference="cCn-3h-med"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/DesignerNewsApp/CommentsTableViewController.swift
+++ b/DesignerNewsApp/CommentsTableViewController.swift
@@ -13,7 +13,7 @@ class CommentsTableViewController: UITableViewController, StoryTableViewCellDele
 
     var story: Story!
     private let transitionManager = TransitionManager()
-    var loginAction: LoginAction?
+    private var loginAction: LoginAction?
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/DesignerNewsApp/CommentsTableViewController.swift
+++ b/DesignerNewsApp/CommentsTableViewController.swift
@@ -13,6 +13,7 @@ class CommentsTableViewController: UITableViewController, StoryTableViewCellDele
 
     var story: Story!
     private let transitionManager = TransitionManager()
+    var loginAction: LoginAction?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -89,13 +90,13 @@ class CommentsTableViewController: UITableViewController, StoryTableViewCellDele
             }
 
         } else {
-            performSegueWithIdentifier("LoginSegue", sender: self)
+            self.loginAction = LoginAction(viewController: self, completion: nil)
         }
     }
 
     func storyTableViewCell(cell: StoryTableViewCell, replyButtonPressed sender: AnyObject) {
         if LocalStore.accessToken() == nil {
-            performSegueWithIdentifier("LoginSegue", sender: self)
+            self.loginAction = LoginAction(viewController: self, completion: nil)
         } else {
             performSegueWithIdentifier("ReplySegue", sender: cell)
         }
@@ -114,7 +115,7 @@ class CommentsTableViewController: UITableViewController, StoryTableViewCellDele
     // MARK: CommentTableViewCellDelegate
     func commentTableViewCell(cell: CommentTableViewCell, replyButtonPressed sender: AnyObject) {
         if LocalStore.accessToken() == nil {
-            performSegueWithIdentifier("LoginSegue", sender: self)
+            self.loginAction = LoginAction(viewController: self, completion: nil)
         } else {
             performSegueWithIdentifier("ReplySegue", sender: cell)
         }
@@ -139,7 +140,7 @@ class CommentsTableViewController: UITableViewController, StoryTableViewCellDele
             }
 
         } else {
-            performSegueWithIdentifier("LoginSegue", sender: self)
+            self.loginAction = LoginAction(viewController: self, completion: nil)
         }
     }
 

--- a/DesignerNewsApp/ContainerViewController.swift
+++ b/DesignerNewsApp/ContainerViewController.swift
@@ -35,14 +35,14 @@ class ContainerViewController: UIPageViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = UIColor.whiteColor()
+        view.backgroundColor = UIColor.whiteColor()
 
-        self.dataSource = self
-        self.delegate = self
+        dataSource = self
+        delegate = self
 
-        self.loginButton.setTitleTextAttributes([NSFontAttributeName: UIFont(name: "Avenir Next", size: 18)!], forState: UIControlState.Normal)
+        loginButton.setTitleTextAttributes([NSFontAttributeName: UIFont(name: "Avenir Next", size: 18)!], forState: UIControlState.Normal)
 
-        self.loginStateChange = LoginStateHandler(handler: { [weak self] (state) -> () in
+        loginStateChange = LoginStateHandler(handler: { [weak self] (state) -> () in
             if state == .LoggedIn {
                 self?.loginButton.title = ""
                 self?.loginButton.enabled = false
@@ -52,12 +52,12 @@ class ContainerViewController: UIPageViewController {
             }
         })
 
-        self.turnToPage(0)
+        turnToPage(0)
     }
 
     func configureForDisplayingViewController(controller: StoriesTableViewController) {
-        self.navigationItem.titleView = controller.navigationItem.titleView
-        self.navigationItem.title = controller.navigationItem.title
+        navigationItem.titleView = controller.navigationItem.titleView
+        navigationItem.title = controller.navigationItem.title
 
         for vc in _controllers {
             // Fix scroll to top when more than one scroll view on screen
@@ -70,7 +70,7 @@ class ContainerViewController: UIPageViewController {
 
         var direction = UIPageViewControllerNavigationDirection.Forward
 
-        if let currentViewController = self.viewControllers.first as? UIViewController {
+        if let currentViewController = viewControllers.first as? UIViewController {
             let currentIndex = (_controllers as NSArray).indexOfObject(currentViewController)
 
             if currentIndex > index {
@@ -78,8 +78,8 @@ class ContainerViewController: UIPageViewController {
             }
         }
 
-        self.configureForDisplayingViewController(controller)
-        self.setViewControllers([controller],
+        configureForDisplayingViewController(controller)
+        setViewControllers([controller],
             direction: direction,
             animated: true) { (completion) -> Void in
 
@@ -99,7 +99,7 @@ class ContainerViewController: UIPageViewController {
 
     @IBAction func loginButtonPressed(sender: AnyObject) {
         if LocalStore.accessToken() == nil {
-            self.loginAction = LoginAction(viewController:self, completion: nil)
+            loginAction = LoginAction(viewController:self, completion: nil)
         } else {
             LogoutAction()
         }
@@ -136,12 +136,12 @@ extension ContainerViewController : UIPageViewControllerDataSource {
 extension ContainerViewController : UIPageViewControllerDelegate {
 
     func pageViewController(pageViewController: UIPageViewController, willTransitionToViewControllers pendingViewControllers: [AnyObject]) {
-        self.configureForDisplayingViewController(pendingViewControllers.first as StoriesTableViewController)
+        configureForDisplayingViewController(pendingViewControllers.first as StoriesTableViewController)
     }
 
     func pageViewController(pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [AnyObject], transitionCompleted completed: Bool) {
         if !completed {
-            self.configureForDisplayingViewController(previousViewControllers.first as StoriesTableViewController)
+            configureForDisplayingViewController(previousViewControllers.first as StoriesTableViewController)
         }
     }
 
@@ -151,23 +151,23 @@ extension  ContainerViewController : MenuViewControllerDelegate {
 
     // MARK: MenuViewControllerDelegate
     func menuViewControllerDidSelectTopStories(controller: MenuViewController) {
-        self.turnToPage(0)
+        turnToPage(0)
     }
 
     func menuViewControllerDidSelectRecent(controller: MenuViewController) {
-        self.turnToPage(1)
+        turnToPage(1)
     }
 
     func menuViewControllerDidSelectCloseMenu(controller: MenuViewController) {
-        self.animateMenuButton()
+        animateMenuButton()
     }
 
     func menuViewControllerDidSelectLogin(controller: MenuViewController) {
-        self.animateMenuButton()
+        animateMenuButton()
     }
 
     func menuViewControllerDidSelectLogout(controller: MenuViewController) {
-        self.animateMenuButton()
+        animateMenuButton()
     }
 
 }

--- a/DesignerNewsApp/ContainerViewController.swift
+++ b/DesignerNewsApp/ContainerViewController.swift
@@ -47,6 +47,10 @@ class ContainerViewController: UIPageViewController {
         for vc in _controllers {
             // Fix login button for the other vc after login/logout
             vc.refreshLoginState()
+
+            // Fix scroll to top when more than one scroll view on screen
+            vc.tableView.scrollsToTop = controller === vc
+        }
     }
 
 }

--- a/DesignerNewsApp/ContainerViewController.swift
+++ b/DesignerNewsApp/ContainerViewController.swift
@@ -29,7 +29,7 @@ class ContainerViewController: UIPageViewController {
         self.delegate = self
 
         let firstViewController = _controllers[0]
-        self.configureNavigationItemWithViewController(firstViewController)
+        self.configureForDisplayingViewController(firstViewController)
         self.setViewControllers([firstViewController],
             direction: UIPageViewControllerNavigationDirection.Forward,
             animated: true) { (completion) -> Void in
@@ -37,11 +37,16 @@ class ContainerViewController: UIPageViewController {
         }
     }
 
-    func configureNavigationItemWithViewController(controller: UIViewController) {
+    func configureForDisplayingViewController(controller: StoriesTableViewController) {
         self.navigationItem.leftBarButtonItem = controller.navigationItem.leftBarButtonItem
         self.navigationItem.titleView = controller.navigationItem.titleView
         self.navigationItem.rightBarButtonItem = controller.navigationItem.rightBarButtonItem
         self.navigationItem.title = controller.navigationItem.title
+
+
+        for vc in _controllers {
+            // Fix login button for the other vc after login/logout
+            vc.refreshLoginState()
     }
 
 }
@@ -75,13 +80,12 @@ extension ContainerViewController : UIPageViewControllerDataSource {
 extension ContainerViewController : UIPageViewControllerDelegate {
 
     func pageViewController(pageViewController: UIPageViewController, willTransitionToViewControllers pendingViewControllers: [AnyObject]) {
-        self.configureNavigationItemWithViewController(pendingViewControllers.first as UIViewController)
-
+        self.configureForDisplayingViewController(pendingViewControllers.first as StoriesTableViewController)
     }
 
     func pageViewController(pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [AnyObject], transitionCompleted completed: Bool) {
         if !completed {
-            self.configureNavigationItemWithViewController(previousViewControllers.first as UIViewController)
+            self.configureForDisplayingViewController(previousViewControllers.first as StoriesTableViewController)
         }
     }
 

--- a/DesignerNewsApp/ContainerViewController.swift
+++ b/DesignerNewsApp/ContainerViewController.swift
@@ -21,6 +21,13 @@ class ContainerViewController: UIPageViewController {
         return [topStories, recentStories]
         }()
 
+    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+        if segue.identifier == "MenuSegue" {
+            let menuViewController = segue.destinationViewController as MenuViewController
+            menuViewController.delegate = self
+        }
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = UIColor.whiteColor()
@@ -28,17 +35,11 @@ class ContainerViewController: UIPageViewController {
         self.dataSource = self
         self.delegate = self
 
-        let firstViewController = _controllers[0]
-        self.configureForDisplayingViewController(firstViewController)
-        self.setViewControllers([firstViewController],
-            direction: UIPageViewControllerNavigationDirection.Forward,
-            animated: true) { (completion) -> Void in
-
-        }
+        self.turnToPage(0)
     }
 
     func configureForDisplayingViewController(controller: StoriesTableViewController) {
-        self.navigationItem.leftBarButtonItem = controller.navigationItem.leftBarButtonItem
+//        self.navigationItem.leftBarButtonItem = controller.navigationItem.leftBarButtonItem
         self.navigationItem.titleView = controller.navigationItem.titleView
         self.navigationItem.rightBarButtonItem = controller.navigationItem.rightBarButtonItem
         self.navigationItem.title = controller.navigationItem.title
@@ -53,6 +54,39 @@ class ContainerViewController: UIPageViewController {
         }
     }
 
+    func turnToPage(index: Int) {
+        let controller = _controllers[index]
+
+        var direction = UIPageViewControllerNavigationDirection.Forward
+
+        if let currentViewController = self.viewControllers.first as? UIViewController {
+            let currentIndex = (_controllers as NSArray).indexOfObject(currentViewController)
+
+            if currentIndex > index {
+                direction = UIPageViewControllerNavigationDirection.Reverse
+            }
+        }
+
+
+        self.configureForDisplayingViewController(controller)
+        self.setViewControllers([controller],
+            direction: direction,
+            animated: true) { (completion) -> Void in
+
+        }
+    }
+
+//    func loginCompleted() {
+//    }
+//
+//    func logout() {
+//        LocalStore.deleteAccessToken()
+//    }
+
+    // MARK: Action
+    @IBAction func menuButtonTouched(sender: AnyObject) {
+        performSegueWithIdentifier("MenuSegue", sender: sender)
+    }
 }
 
 extension ContainerViewController : UIPageViewControllerDataSource {
@@ -90,6 +124,33 @@ extension ContainerViewController : UIPageViewControllerDelegate {
     func pageViewController(pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [AnyObject], transitionCompleted completed: Bool) {
         if !completed {
             self.configureForDisplayingViewController(previousViewControllers.first as StoriesTableViewController)
+        }
+    }
+
+}
+
+extension  ContainerViewController : MenuViewControllerDelegate {
+
+    // MARK: MenuViewControllerDelegate
+    func menuViewControllerDidSelectTopStories(controller: MenuViewController) {
+        self.turnToPage(0)
+    }
+
+    func menuViewControllerDidSelectRecent(controller: MenuViewController) {
+        self.turnToPage(1)
+    }
+
+    func menuViewControllerDidSelectLogout(controller: MenuViewController) {
+//        logout()
+    }
+
+    func menuViewControllerDidSelectLogin(controller: MenuViewController) {
+//        loginCompleted()
+    }
+
+    func menuViewControllerDidSelectCloseMenu(controller: MenuViewController) {
+        if let button = navigationItem.leftBarButtonItem?.customView as? MenuControl {
+            button.menuAnimation()
         }
     }
 

--- a/DesignerNewsApp/ContainerViewController.swift
+++ b/DesignerNewsApp/ContainerViewController.swift
@@ -12,8 +12,8 @@ class ContainerViewController: UIPageViewController {
 
     @IBOutlet weak var loginButton: UIBarButtonItem!
 
-    var loginAction : LoginAction?
-    var loginStateChange : LoginStateHandler?
+    private var loginAction : LoginAction?
+    private var loginStateChange : LoginStateHandler?
 
     lazy var _controllers : [StoriesTableViewController] = {
         let topStories = self.storyboard?.instantiateViewControllerWithIdentifier("StoriesTableViewController") as StoriesTableViewController

--- a/DesignerNewsApp/ContainerViewController.swift
+++ b/DesignerNewsApp/ContainerViewController.swift
@@ -1,0 +1,88 @@
+//
+//  ContainerViewController.swift
+//  DesignerNewsApp
+//
+//  Created by James Tang on 16/3/15.
+//  Copyright (c) 2015 Meng To. All rights reserved.
+//
+
+import UIKit
+
+class ContainerViewController: UIPageViewController {
+
+    lazy var _controllers : [StoriesTableViewController] = {
+        let topStories = self.storyboard?.instantiateViewControllerWithIdentifier("StoriesTableViewController") as StoriesTableViewController
+
+
+        let recentStories = self.storyboard?.instantiateViewControllerWithIdentifier("StoriesTableViewController") as StoriesTableViewController
+
+        recentStories.storySection = .Recent
+
+        return [topStories, recentStories]
+        }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = UIColor.whiteColor()
+
+        self.dataSource = self
+        self.delegate = self
+
+        let firstViewController = _controllers[0]
+        self.configureNavigationItemWithViewController(firstViewController)
+        self.setViewControllers([firstViewController],
+            direction: UIPageViewControllerNavigationDirection.Forward,
+            animated: true) { (completion) -> Void in
+
+        }
+    }
+
+    func configureNavigationItemWithViewController(controller: UIViewController) {
+        self.navigationItem.leftBarButtonItem = controller.navigationItem.leftBarButtonItem
+        self.navigationItem.titleView = controller.navigationItem.titleView
+        self.navigationItem.rightBarButtonItem = controller.navigationItem.rightBarButtonItem
+        self.navigationItem.title = controller.navigationItem.title
+    }
+
+}
+
+extension ContainerViewController : UIPageViewControllerDataSource {
+
+    func pageViewController(pageViewController: UIPageViewController, viewControllerBeforeViewController viewController: UIViewController) -> UIViewController? {
+
+        let index = (_controllers as NSArray).indexOfObject(viewController)
+
+        if index > 0 {
+            return _controllers[index - 1]
+        }
+
+        return nil
+    }
+
+    func pageViewController(pageViewController: UIPageViewController, viewControllerAfterViewController viewController: UIViewController) -> UIViewController? {
+
+        let index = (_controllers as NSArray).indexOfObject(viewController)
+
+        if index < _controllers.count - 1 {
+            return _controllers[index + 1]
+        }
+
+        return nil
+    }
+
+}
+
+extension ContainerViewController : UIPageViewControllerDelegate {
+
+    func pageViewController(pageViewController: UIPageViewController, willTransitionToViewControllers pendingViewControllers: [AnyObject]) {
+        self.configureNavigationItemWithViewController(pendingViewControllers.first as UIViewController)
+
+    }
+
+    func pageViewController(pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [AnyObject], transitionCompleted completed: Bool) {
+        if !completed {
+            self.configureNavigationItemWithViewController(previousViewControllers.first as UIViewController)
+        }
+    }
+
+}

--- a/DesignerNewsApp/LocalStore.swift
+++ b/DesignerNewsApp/LocalStore.swift
@@ -61,7 +61,7 @@ struct LocalStore {
         userDefaults.synchronize()
     }
 
-    static func deleteAccessToken() {
+    private static func deleteAccessToken() {
         userDefaults.removeObjectForKey(accessTokenKey)
         userDefaults.synchronize()
     }
@@ -74,6 +74,10 @@ struct LocalStore {
 
     static func accessToken() -> String? {
         return userDefaults.stringForKey(accessTokenKey)
+    }
+
+    static func logout() {
+        self.deleteAccessToken()
     }
 
     // MARK: Helper

--- a/DesignerNewsApp/LoginService.swift
+++ b/DesignerNewsApp/LoginService.swift
@@ -19,7 +19,7 @@ class LoginAction : NSObject, LoginViewControllerDelegate {
 
     init(viewController: UIViewController, completion: LoginHandler?) {
         super.init()
-        self.loginHandler = completion
+        loginHandler = completion
         let loginViewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewControllerWithIdentifier("LoginViewController") as LoginViewController
         loginViewController.modalPresentationStyle = .OverCurrentContext
         loginViewController.modalTransitionStyle = .CrossDissolve

--- a/DesignerNewsApp/LoginService.swift
+++ b/DesignerNewsApp/LoginService.swift
@@ -1,0 +1,77 @@
+//
+//  LoginService.swift
+//  DesignerNewsApp
+//
+//  Created by James Tang on 18/3/15.
+//  Copyright (c) 2015 Meng To. All rights reserved.
+//
+
+import UIKit
+
+private let LoginNotification = "UserDidLoginNotification"
+private let LogoutNotification = "UserDidLogoutNotification"
+
+class LoginAction : NSObject, LoginViewControllerDelegate {
+
+    typealias LoginHandler = ()->()
+
+    private var loginHandler : LoginHandler?
+
+    init(viewController: UIViewController, completion: LoginHandler?) {
+        super.init()
+        self.loginHandler = completion
+        let loginViewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewControllerWithIdentifier("LoginViewController") as LoginViewController
+        loginViewController.modalPresentationStyle = .OverCurrentContext
+        loginViewController.modalTransitionStyle = .CrossDissolve
+        loginViewController.delegate = self
+        viewController.presentViewController(loginViewController, animated: false, completion: nil)
+    }
+
+    func didLogin(completion: LoginHandler) {
+        loginHandler = completion
+    }
+
+    func loginViewControllerDidLogin(controller: LoginViewController) {
+        loginHandler?()
+        NSNotificationCenter.defaultCenter().postNotificationName(LoginNotification, object: nil)
+    }
+}
+
+class LogoutAction : NSObject {
+
+    override init() {
+        super.init()
+        LocalStore.logout()
+        NSNotificationCenter.defaultCenter().postNotificationName(LogoutNotification, object: nil)
+    }
+}
+
+class LoginStateHandler : NSObject {
+
+    typealias ChangeHandler = (LoginState)->()
+
+    enum LoginState {
+        case LoggedIn, LoggedOut
+    }
+
+    private var changeHandler : ChangeHandler?
+
+    init(handler : ChangeHandler) {
+        super.init()
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "loginNotification:", name: LoginNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "logoutNotification:", name: LogoutNotification, object: nil)
+        changeHandler = handler
+        let isLoggedIn = LocalStore.accessToken() != nil
+        handler(isLoggedIn ? .LoggedIn : .LoggedOut)
+    }
+
+    func loginNotification(notification: NSNotification) {
+        changeHandler?(.LoggedIn)
+    }
+
+    func logoutNotification(notification: NSNotification) {
+        changeHandler?(.LoggedOut)
+    }
+
+}
+

--- a/DesignerNewsApp/LoginService.swift
+++ b/DesignerNewsApp/LoginService.swift
@@ -65,6 +65,10 @@ class LoginStateHandler : NSObject {
         handler(isLoggedIn ? .LoggedIn : .LoggedOut)
     }
 
+    deinit {
+        NSNotificationCenter.defaultCenter().removeObserver(self)
+    }
+
     func loginNotification(notification: NSNotification) {
         changeHandler?(.LoggedIn)
     }

--- a/DesignerNewsApp/MenuViewController.swift
+++ b/DesignerNewsApp/MenuViewController.swift
@@ -25,8 +25,8 @@ class MenuViewController: UIViewController {
     @IBOutlet weak var recentLabel: UILabel!
     @IBOutlet weak var creditsLabel: UILabel!
     @IBOutlet weak var loginLabel: UILabel!
-    var loginAction : LoginAction?
-    var loginStateHandler: LoginStateHandler?
+    private var loginAction : LoginAction?
+    private var loginStateHandler: LoginStateHandler?
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/DesignerNewsApp/StoriesTableViewController.swift
+++ b/DesignerNewsApp/StoriesTableViewController.swift
@@ -45,7 +45,9 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
         navigationItem.leftBarButtonItem?.setTitleTextAttributes([NSFontAttributeName: UIFont(name: "Avenir Next", size: 18)!], forState: UIControlState.Normal)
 
         self.loginStateHandler = LoginStateHandler(handler: { [weak self] (state) -> () in
-            self?.loadStories()
+            if let strongSelf = self {
+                strongSelf.loadStories()
+            }
         })
     }
 

--- a/DesignerNewsApp/StoriesTableViewController.swift
+++ b/DesignerNewsApp/StoriesTableViewController.swift
@@ -16,6 +16,22 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
     private var firstTime = true
     private var storiesLoader = StoriesLoader()
     private var selectedIndexPath : NSIndexPath?
+    var storySection : StoriesLoader.StorySection = .Default {
+        didSet {
+            storiesLoader = StoriesLoader(storySection)
+
+            switch (storySection) {
+            case .Default:
+                title = "Top Stories"
+            case .Recent:
+                title = "Recent Stories"
+            }
+
+            if self.isViewLoaded() {
+                loadStories()
+            }
+        }
+    }
 
     @IBOutlet weak var loginButton: UIBarButtonItem!
     
@@ -81,15 +97,11 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
     
     // MARK: MenuViewControllerDelegate
     func menuViewControllerDidSelectTopStories(controller: MenuViewController) {
-        title = "Top Stories"
-        storiesLoader = StoriesLoader(.Default)
-        loadStories()
+        self.storySection = .Default
     }
     
     func menuViewControllerDidSelectRecent(controller: MenuViewController) {
-        title = "Recent Stories"
-        storiesLoader = StoriesLoader(.Recent)
-        loadStories()
+        self.storySection = .Recent
     }
 
     func menuViewControllerDidSelectLogout(controller: MenuViewController) {

--- a/DesignerNewsApp/StoriesTableViewController.swift
+++ b/DesignerNewsApp/StoriesTableViewController.swift
@@ -16,6 +16,9 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
     private var firstTime = true
     private var storiesLoader = StoriesLoader()
     private var selectedIndexPath : NSIndexPath?
+    private var loginStateHandler : LoginStateHandler!
+    private var loginAction : LoginAction?
+
     var storySection : StoriesLoader.StorySection = .Default {
         didSet {
             storiesLoader = StoriesLoader(storySection)
@@ -40,6 +43,10 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
         tableView.rowHeight = UITableViewAutomaticDimension
         
         navigationItem.leftBarButtonItem?.setTitleTextAttributes([NSFontAttributeName: UIFont(name: "Avenir Next", size: 18)!], forState: UIControlState.Normal)
+
+        self.loginStateHandler = LoginStateHandler(handler: { [weak self] (state) -> () in
+            self?.loadStories()
+        })
     }
 
     override func viewWillAppear(animated: Bool) {
@@ -140,7 +147,7 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
                 }
             }
         } else {
-            performSegueWithIdentifier("LoginSegue", sender: self)
+            self.loginAction = LoginAction(viewController: self, completion: nil)
         }
     }
 

--- a/DesignerNewsApp/StoriesTableViewController.swift
+++ b/DesignerNewsApp/StoriesTableViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Spring
 
-class StoriesTableViewController: UITableViewController, StoryTableViewCellDelegate, LoginViewControllerDelegate, MenuViewControllerDelegate {
+class StoriesTableViewController: UITableViewController, StoryTableViewCellDelegate, LoginViewControllerDelegate {
     
     private let transitionManager = TransitionManager()
     private var stories = [Story]()
@@ -98,29 +98,6 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
             loginButton.enabled = false
         }
     }
-    
-    // MARK: MenuViewControllerDelegate
-    func menuViewControllerDidSelectTopStories(controller: MenuViewController) {
-        self.storySection = .Default
-    }
-    
-    func menuViewControllerDidSelectRecent(controller: MenuViewController) {
-        self.storySection = .Recent
-    }
-
-    func menuViewControllerDidSelectLogout(controller: MenuViewController) {
-        logout()
-    }
-
-    func menuViewControllerDidSelectLogin(controller: MenuViewController) {
-        loginCompleted()
-    }
-
-    func menuViewControllerDidSelectCloseMenu(controller: MenuViewController) {
-        if let button = navigationItem.leftBarButtonItem?.customView as? MenuControl {
-            button.menuAnimation()
-        }
-    }
 
     // MARK: LoginViewControllerDelegate
     func loginViewControllerDidLogin(controller: LoginViewController) {
@@ -134,10 +111,6 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
         } else {
             logout()
         }
-    }
-
-    @IBAction func menuButtonTouched(sender: AnyObject) {
-        performSegueWithIdentifier("MenuSegue", sender: sender)
     }
 
     @IBAction func refreshControlValueChanged(sender: AnyObject) {
@@ -249,10 +222,6 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
         else if segue.identifier == "LoginSegue" {
             let loginViewController = segue.destinationViewController as LoginViewController
             loginViewController.delegate = self
-        }
-        else if segue.identifier == "MenuSegue" {
-            let menuViewController = segue.destinationViewController as MenuViewController
-            menuViewController.delegate = self
         }
     }
 

--- a/DesignerNewsApp/StoriesTableViewController.swift
+++ b/DesignerNewsApp/StoriesTableViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Spring
 
-class StoriesTableViewController: UITableViewController, StoryTableViewCellDelegate, LoginViewControllerDelegate {
+class StoriesTableViewController: UITableViewController, StoryTableViewCellDelegate {
     
     private let transitionManager = TransitionManager()
     private var stories = [Story]()
@@ -32,8 +32,6 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
             }
         }
     }
-
-    @IBOutlet weak var loginButton: UIBarButtonItem!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -42,8 +40,6 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
         tableView.rowHeight = UITableViewAutomaticDimension
         
         navigationItem.leftBarButtonItem?.setTitleTextAttributes([NSFontAttributeName: UIFont(name: "Avenir Next", size: 18)!], forState: UIControlState.Normal)
-        
-        loginButton.setTitleTextAttributes([NSFontAttributeName: UIFont(name: "Avenir Next", size: 18)!], forState: UIControlState.Normal)
     }
 
     override func viewWillAppear(animated: Bool) {
@@ -78,8 +74,6 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
             self.view.hideLoading()
             self.refreshControl?.endRefreshing()
         })
-
-        refreshLoginState()
     }
 
     func loadMoreStories() {
@@ -89,42 +83,8 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
         }
     }
 
-    func refreshLoginState() {
-        if LocalStore.accessToken() == nil {
-            loginButton.title = "Login"
-            loginButton.enabled = true
-        } else {
-            loginButton.title = ""
-            loginButton.enabled = false
-        }
-    }
-
-    // MARK: LoginViewControllerDelegate
-    func loginViewControllerDidLogin(controller: LoginViewController) {
-        loginCompleted()
-    }
-
-    // MARK: Action
-    @IBAction func loginButtonPressed(sender: AnyObject) {
-        if LocalStore.accessToken() == nil {
-            performSegueWithIdentifier("LoginSegue", sender: self)
-        } else {
-            logout()
-        }
-    }
-
     @IBAction func refreshControlValueChanged(sender: AnyObject) {
         self.loadStories()
-    }
-
-    // MARK: Misc
-    func loginCompleted() {
-        loadStories()
-    }
-
-    func logout() {
-        LocalStore.deleteAccessToken()
-        loadStories()
     }
 
     // MARK: TableViewDelegate
@@ -218,10 +178,6 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
             webViewController.transitioningDelegate = self.transitionManager
             
             UIApplication.sharedApplication().setStatusBarHidden(true, withAnimation: UIStatusBarAnimation.Slide)
-        }
-        else if segue.identifier == "LoginSegue" {
-            let loginViewController = segue.destinationViewController as LoginViewController
-            loginViewController.delegate = self
         }
     }
 

--- a/DesignerNewsApp/StoriesTableViewController.swift
+++ b/DesignerNewsApp/StoriesTableViewController.swift
@@ -79,19 +79,23 @@ class StoriesTableViewController: UITableViewController, StoryTableViewCellDeleg
             self.refreshControl?.endRefreshing()
         })
 
-        if LocalStore.accessToken() == nil {
-            loginButton.title = "Login"
-            loginButton.enabled = true
-        } else {
-            loginButton.title = ""
-            loginButton.enabled = false
-        }
+        refreshLoginState()
     }
 
     func loadMoreStories() {
         storiesLoader.next { [unowned self] stories in
             self.stories += stories
             self.tableView.reloadData()
+        }
+    }
+
+    func refreshLoginState() {
+        if LocalStore.accessToken() == nil {
+            loginButton.title = "Login"
+            loginButton.enabled = true
+        } else {
+            loginButton.title = ""
+            loginButton.enabled = false
         }
     }
     


### PR DESCRIPTION
Closing #92. This requirement introduced a situation that more than one **StoryTableViewController** will be on screen at the same time. Using delegate pattern in **LoginViewControllerDelegate** is not able to tell every VC instance to do proper operation when user login/logouts.

Therefore this has to include a refactor on how to deal with Login status changes, which will encapsulate in three classes, all inside `LoginService.swift`.

**LoginStateHandler** is an observer and automatically fires when user login or logout.
**LoginAction** is a reusable class that automatically configures and presents our **LoginViewController** so we can remove all the duplicated segues which was everywhere in Storyboard
**LogoutAction** is also a reusable class to perform correct clean up operation.