### PR TITLE
Simple fix for url copying

### DIFF
--- a/DesignerNewsApp/WebViewController.swift
+++ b/DesignerNewsApp/WebViewController.swift
@@ -67,7 +67,7 @@ class WebViewController: UIViewController, UIWebViewDelegate, UIScrollViewDelega
     
     @IBAction func shareButtonPressed(sender: AnyObject) {
         let shareString = self.shareTitle ?? ""
-        let shareURL = self.url
+        let shareURL = webView.request!.URL!
         let activityViewController = UIActivityViewController(activityItems: [shareString, shareURL], applicationActivities: [SafariActivity(), ChromeActivity()])
         activityViewController.setValue(shareString, forKey: "subject")
         activityViewController.excludedActivityTypes = [UIActivityTypeAirDrop]

--- a/DesignerNewsApp/WebViewController.swift
+++ b/DesignerNewsApp/WebViewController.swift
@@ -67,7 +67,7 @@ class WebViewController: UIViewController, UIWebViewDelegate, UIScrollViewDelega
     
     @IBAction func shareButtonPressed(sender: AnyObject) {
         let shareString = self.shareTitle ?? ""
-        let shareURL = webView.request!.URL!
+        let shareURL = self.url
         let activityViewController = UIActivityViewController(activityItems: [shareString, shareURL], applicationActivities: [SafariActivity(), ChromeActivity()])
         activityViewController.setValue(shareString, forKey: "subject")
         activityViewController.excludedActivityTypes = [UIActivityTypeAirDrop]
@@ -111,6 +111,7 @@ class WebViewController: UIViewController, UIWebViewDelegate, UIScrollViewDelega
 
     func webViewDidFinishLoad(webView: UIWebView) {
         shareTitle = webView.stringByEvaluatingJavaScriptFromString("document.title");
+        url = webView.request!.URL!
         delay(1) { [weak self] in
             if let _self = self {
                 _self.hasFinishLoading = true


### PR DESCRIPTION
Fixes #103.

If we change the copied url from the Designer News page to the actual webpage loaded in the web view, users can navigate to different pages in the web view and share them without losing their links. Now, both the title and the url of the page they're on gets copied when they use the share sheet.

Note: This works with both `Copy` and `Open in Safari`. I imagine it works with `Open in Chrome` as well, but wasn't able to test that.

This app is brilliant, by the way! The animations are subtle, but delightful.