### PR TITLE
Feature/api endpoint

### DIFF
--- a/DesignerNewsApp/DesignerNewsService.swift
+++ b/DesignerNewsApp/DesignerNewsService.swift
@@ -12,7 +12,7 @@ struct DesignerNewsService {
 
     // Designer News API Doc: http://developers.news.layervault.com
 
-    private static let baseURL = "https://api-news.layervault.com"
+    private static let baseURL = "https://www.designernews.co"
     private static let clientID = "750ab22aac78be1c6d4bbe584f0e3477064f646720f327c5464bc127100a1a6d"
     private static let clientSecret = "53e3822c49287190768e009a8f8e55d09041c5bf26d0ef982693f215c72d87da"
 

--- a/DesignerNewsApp/DesignerNewsService.swift
+++ b/DesignerNewsApp/DesignerNewsService.swift
@@ -11,6 +11,7 @@ import Alamofire
 struct DesignerNewsService {
 
     // Designer News API Doc: http://developers.news.layervault.com
+    //                    V2: https://github.com/metalabdesign/dn_api_v2
 
     private static let baseURL = "https://www.designernews.co"
     private static let clientID = "750ab22aac78be1c6d4bbe584f0e3477064f646720f327c5464bc127100a1a6d"


### PR DESCRIPTION
This feature closes #107.

We can still decide if we want to migrate to the V2 API.