### PR TITLE
Logic Error

### DIFF
--- a/DesignerNewsApp/ContainerViewController.swift
+++ b/DesignerNewsApp/ContainerViewController.swift
@@ -172,12 +172,6 @@ extension ContainerViewController : UIPageViewControllerDelegate {
         configureForDisplayingViewController(pendingViewControllers.first as! StoriesTableViewController)
     }
 
-    func pageViewController(pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [AnyObject], transitionCompleted completed: Bool) {
-        if !completed {
-            configureForDisplayingViewController(previousViewControllers.first as! StoriesTableViewController)
-        }
-    }
-
 }
 
 extension  ContainerViewController : MenuViewControllerDelegate {


### PR DESCRIPTION
I think there is logic error.
Use previousViewController to update UI after page turn to next page.
But this deleage function don't callback on xcode6.4 when I test,so I don't find error when only test with simulator.